### PR TITLE
Fix PHYFS path separators.

### DIFF
--- a/addons/physfs/a5_physfs.c
+++ b/addons/physfs/a5_physfs.c
@@ -66,7 +66,7 @@ static void *file_phys_fopen(const char *filename, const char *mode)
    PHYSFS_file *phys;
    ALLEGRO_FILE_PHYSFS *fp;
 
-   us = _al_physfs_apply_cwd(filename);
+   us = _al_physfs_process_path(filename);
 
    /* XXX handle '+' modes */
    /* It might be worth adding a function to parse mode strings, to be

--- a/addons/physfs/allegro_physfs_intern.h
+++ b/addons/physfs/allegro_physfs_intern.h
@@ -3,6 +3,6 @@
 
 void _al_set_physfs_fs_interface(void);
 const ALLEGRO_FILE_INTERFACE *_al_get_phys_vtable(void);
-ALLEGRO_USTR *_al_physfs_apply_cwd(const char *path);
+ALLEGRO_USTR *_al_physfs_process_path(const char *path);
 
 #endif


### PR DESCRIPTION
PHYSFS always uses forward slashes, which causes problems for people
that use ALLEGRO_NATIVE_PATH_SEP to handle paths while PHYFS file
interface is active. Now we fix up the separators to get that to work.